### PR TITLE
:NORMAL: Feature/add serialised names [Medium PR]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ allprojects {
 		mavenCentral()
 		maven {
 			url 'http://oss.3sidedcube.com:8081/artifactory/internal'
+			allowInsecureProtocol = true
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.2.0'
+		classpath 'com.android.tools.build:gradle:8.13.0'
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.8.0-beta01
+VERSION_NAME=1.8.0-rc1
 GROUP=com.3sidedcube.util
 
 POM_NAME=GeoGson

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7
+VERSION_NAME=1.8.0-beta01
 GROUP=com.3sidedcube.util
 
 POM_NAME=GeoGson

--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -21,77 +21,62 @@
  * the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
-
-def setupPomInfo(pom)
-{
-	pom.groupId = GROUP
-	pom.artifactId = POM_ARTIFACT_ID
-	pom.version = VERSION_NAME
-
-	pom.project {
-		name POM_NAME
-		packaging POM_PACKAGING
-		description POM_DESCRIPTION
-		url POM_URL
-
-		scm {
-			url POM_SCM_URL
-			connection POM_SCM_CONNECTION
-			developerConnection POM_SCM_DEV_CONNECTION
-		}
-
-		licenses {
-			license {
-				name POM_LICENSE_NAME
-				url POM_LICENSE_URL
-				distribution 'repo'
-			}
-		}
-
-		developers {
-			developer {
-				id POM_DEVELOPER_ID
-				name POM_DEVELOPER_NAME
-			}
-		}
-	}
-}
-
-// Extra task definition is needed to work around naming conflict between maven and android plugins
-// http://stackoverflow.com/questions/18559932
-task installArchives(type: Upload) {
-	description "Installs artifacts to mavenLocal."
-	repositories.mavenInstaller {
-		configuration = configurations.default
-		setupPomInfo(pom)
-	}
-}
 
 ext.ARTIFACTORY_USERNAME = properties.get('ARTIFACTORY_USERNAME', '')
 ext.ARTIFACTORY_PASSWORD = properties.get('ARTIFACTORY_PASSWORD', '')
 
 afterEvaluate { project ->
-	uploadArchives {
-		repositories {
-			mavenDeployer {
-				beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-				setupPomInfo(pom)
+	publishing {
+		publications {
+			mavenJava(MavenPublication) {
+				from components.findByName('release')
+				groupId = GROUP
+				artifactId = POM_ARTIFACT_ID
+				version = VERSION_NAME
 
-				repository(url: 'http://oss.3sidedcube.com:8081/artifactory/internal') {
-					authentication(userName: ARTIFACTORY_USERNAME, password: ARTIFACTORY_PASSWORD)
+				pom {
+					name = POM_NAME
+					packaging = POM_PACKAGING
+					description = POM_DESCRIPTION
+					url = POM_URL
+
+					scm {
+						url = POM_SCM_URL
+						connection = POM_SCM_CONNECTION
+						developerConnection = POM_SCM_DEV_CONNECTION
+					}
+
+					licenses {
+						license {
+							name = POM_LICENSE_NAME
+							url = POM_LICENSE_URL
+							distribution = 'repo'
+						}
+					}
+
+					developers {
+						developer {
+							id = POM_DEVELOPER_ID
+							name = POM_DEVELOPER_NAME
+						}
+					}
 				}
-
-				snapshotRepository(url: 'http://oss.3sidedcube.com:8081/artifactory/snapshot') {
-					authentication(userName: ARTIFACTORY_USERNAME, password: ARTIFACTORY_PASSWORD)
+			}
+		}
+		repositories {
+			maven {
+				url = "http://oss.3sidedcube.com:8081/artifactory/private"
+				allowInsecureProtocol = true
+				credentials {
+					username = ARTIFACTORY_USERNAME
+					password = ARTIFACTORY_PASSWORD
 				}
 			}
 		}
 	}
-
 	signing {
-		required { gradle.taskGraph.hasTask("uploadArchives") }
-		sign configurations.archives
+		sign publishing.publications.mavenJava
 	}
 }

--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -31,7 +31,7 @@ afterEvaluate { project ->
 	publishing {
 		publications {
 			mavenJava(MavenPublication) {
-				from components.findByName('release')
+				from components.java
 				groupId = GROUP
 				artifactId = POM_ARTIFACT_ID
 				version = VERSION_NAME
@@ -67,7 +67,7 @@ afterEvaluate { project ->
 		}
 		repositories {
 			maven {
-				url = "http://oss.3sidedcube.com:8081/artifactory/private"
+				url = "http://oss.3sidedcube.com:8081/artifactory/internal"
 				allowInsecureProtocol = true
 				credentials {
 					username = ARTIFACTORY_USERNAME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Oct 08 12:26:31 BST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-milestone-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 compileJava {
-	sourceCompatibility = 1.7
-	targetCompatibility = 1.7
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,9 +10,9 @@ compileJava {
 }
 
 dependencies {
-	compile "com.google.code.gson:gson:2.3"
-	testCompile "org.mockito:mockito-all:1.9.5"
-	testCompile "junit:junit:4.11"
+	implementation "com.google.code.gson:gson:2.13.2"
+	testImplementation "org.mockito:mockito-all:1.9.5"
+	testImplementation "junit:junit:4.13.2"
 }
 
 //apply from: '../gradle/sonatype.gradle'

--- a/library/src/main/java/com/cube/geojson/Circle.java
+++ b/library/src/main/java/com/cube/geojson/Circle.java
@@ -2,27 +2,29 @@ package com.cube.geojson;
 
 public class Circle extends Point
 {
+	public static String TYPE_NAME = "Circle";
 	private double radius;
 
 	public Circle()
 	{
+		super(TYPE_NAME);
 	}
 
 	public Circle(LngLatAlt coordinates, double radius)
 	{
-		super(coordinates);
+		super(TYPE_NAME, coordinates);
 		this.radius = radius;
 	}
 
 	public Circle(double longitude, double latitude, double radius)
 	{
-		super(longitude, latitude);
+		super(TYPE_NAME, longitude, latitude);
 		this.radius = radius;
 	}
 
 	public Circle(double longitude, double latitude, double altitude, double radius)
 	{
-		super(longitude, latitude, altitude);
+		super(TYPE_NAME, longitude, latitude, altitude);
 		this.radius = radius;
 	}
 

--- a/library/src/main/java/com/cube/geojson/Circle.java
+++ b/library/src/main/java/com/cube/geojson/Circle.java
@@ -1,9 +1,11 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Circle extends Point
 {
 	public static String TYPE_NAME = "Circle";
-	private double radius;
+	@SerializedName("radius") private double radius;
 
 	public Circle()
 	{

--- a/library/src/main/java/com/cube/geojson/Crs.java
+++ b/library/src/main/java/com/cube/geojson/Crs.java
@@ -1,12 +1,14 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public class Crs
 {
-	private String type = "name";
-	private Map<String, Object> properties = new HashMap<String, Object>();
+	@SerializedName("type") private String type = "name";
+	@SerializedName("properties") private Map<String, Object> properties = new HashMap<>();
 
 	public String getType()
 	{

--- a/library/src/main/java/com/cube/geojson/Feature.java
+++ b/library/src/main/java/com/cube/geojson/Feature.java
@@ -1,10 +1,12 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Feature extends GeoJsonObject
 {
 	public static String TYPE_NAME = "Feature";
-	private GeoJsonObject geometry;
-	private String id;
+	@SerializedName("geometry") private GeoJsonObject geometry;
+	@SerializedName("id") private String id;
 
 	public Feature() {
 		super(TYPE_NAME);

--- a/library/src/main/java/com/cube/geojson/Feature.java
+++ b/library/src/main/java/com/cube/geojson/Feature.java
@@ -2,8 +2,13 @@ package com.cube.geojson;
 
 public class Feature extends GeoJsonObject
 {
+	public static String TYPE_NAME = "Feature";
 	private GeoJsonObject geometry;
 	private String id;
+
+	public Feature() {
+		super(TYPE_NAME);
+	}
 
 	public GeoJsonObject getGeometry()
 	{

--- a/library/src/main/java/com/cube/geojson/FeatureCollection.java
+++ b/library/src/main/java/com/cube/geojson/FeatureCollection.java
@@ -1,5 +1,7 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -14,7 +16,7 @@ public class FeatureCollection extends GeoJsonObject implements Iterable<Feature
 		super(TYPE_NAME);
 	}
 
-	private List<Feature> features = new ArrayList<Feature>();
+	@SerializedName("features") private List<Feature> features = new ArrayList<>();
 
 	public List<Feature> getFeatures()
 	{

--- a/library/src/main/java/com/cube/geojson/FeatureCollection.java
+++ b/library/src/main/java/com/cube/geojson/FeatureCollection.java
@@ -7,6 +7,13 @@ import java.util.List;
 
 public class FeatureCollection extends GeoJsonObject implements Iterable<Feature>
 {
+	public static String TYPE_NAME = "FeatureCollection";
+
+	public FeatureCollection()
+	{
+		super(TYPE_NAME);
+	}
+
 	private List<Feature> features = new ArrayList<Feature>();
 
 	public List<Feature> getFeatures()

--- a/library/src/main/java/com/cube/geojson/GeoJsonObject.java
+++ b/library/src/main/java/com/cube/geojson/GeoJsonObject.java
@@ -1,16 +1,18 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class GeoJsonObject implements Serializable
 {
-	protected String type;
-	private Crs crs;
-	private double[] bbox;
+	@SerializedName("type") protected String type;
+	@SerializedName("crs") private Crs crs;
+	@SerializedName("bbox") private double[] bbox;
 
-	private Map<String, Object> properties;
+	@SerializedName("properties") private Map<String, Object> properties;
 
 	public void setType(String type)
 	{

--- a/library/src/main/java/com/cube/geojson/GeoJsonObject.java
+++ b/library/src/main/java/com/cube/geojson/GeoJsonObject.java
@@ -22,9 +22,9 @@ public abstract class GeoJsonObject implements Serializable
 		return this.type;
 	}
 
-	public GeoJsonObject()
+	protected GeoJsonObject(String type)
 	{
-		type = getClass().getSimpleName();
+		this.type = type;
 	}
 
 	public Crs getCrs()

--- a/library/src/main/java/com/cube/geojson/Geometry.java
+++ b/library/src/main/java/com/cube/geojson/Geometry.java
@@ -1,11 +1,13 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class Geometry<T> extends GeoJsonObject
 {
-	protected List<T> coordinates = new ArrayList<T>();
+	@SerializedName("coordinates") protected List<T> coordinates = new ArrayList<>();
 
 	protected Geometry(String type)
 	{

--- a/library/src/main/java/com/cube/geojson/Geometry.java
+++ b/library/src/main/java/com/cube/geojson/Geometry.java
@@ -7,12 +7,14 @@ public abstract class Geometry<T> extends GeoJsonObject
 {
 	protected List<T> coordinates = new ArrayList<T>();
 
-	public Geometry()
+	protected Geometry(String type)
 	{
+		super(type);
 	}
 
-	public Geometry(T... elements)
+	protected Geometry(String type, T... elements)
 	{
+		super(type);
 		for (T coordinate : elements)
 		{
 			coordinates.add(coordinate);

--- a/library/src/main/java/com/cube/geojson/GeometryCollection.java
+++ b/library/src/main/java/com/cube/geojson/GeometryCollection.java
@@ -1,5 +1,7 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -13,7 +15,7 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 		super(TYPE_NAME);
 	}
 
-	private List<GeoJsonObject> geometries = new ArrayList<GeoJsonObject>();
+	@SerializedName("geometries") private List<GeoJsonObject> geometries = new ArrayList<>();
 
 	public List<GeoJsonObject> getGeometries()
 	{

--- a/library/src/main/java/com/cube/geojson/GeometryCollection.java
+++ b/library/src/main/java/com/cube/geojson/GeometryCollection.java
@@ -6,6 +6,13 @@ import java.util.List;
 
 public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJsonObject>
 {
+	public static String TYPE_NAME = "GeometryCollection";
+
+	public GeometryCollection()
+	{
+		super(TYPE_NAME);
+	}
+
 	private List<GeoJsonObject> geometries = new ArrayList<GeoJsonObject>();
 
 	public List<GeoJsonObject> getGeometries()

--- a/library/src/main/java/com/cube/geojson/LineString.java
+++ b/library/src/main/java/com/cube/geojson/LineString.java
@@ -3,12 +3,15 @@ package com.cube.geojson;
 
 public class LineString extends MultiPoint
 {
+	public static String TYPE_NAME = "LineString";
+
 	public LineString()
 	{
+		super(TYPE_NAME);
 	}
 
 	public LineString(LngLatAlt... points)
 	{
-		super(points);
+		super(TYPE_NAME, points);
 	}
 }

--- a/library/src/main/java/com/cube/geojson/LngLatAlt.java
+++ b/library/src/main/java/com/cube/geojson/LngLatAlt.java
@@ -1,12 +1,14 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.io.Serializable;
 
 public class LngLatAlt implements Serializable
 {
-	private double longitude;
-	private double latitude;
-	private double altitude = Double.NaN;
+	@SerializedName("longitude") private double longitude;
+	@SerializedName("latitude") private double latitude;
+	@SerializedName("altitude") private double altitude = Double.NaN;
 
 	public LngLatAlt()
 	{

--- a/library/src/main/java/com/cube/geojson/MultiLineString.java
+++ b/library/src/main/java/com/cube/geojson/MultiLineString.java
@@ -4,8 +4,11 @@ import java.util.List;
 
 public class MultiLineString extends Geometry<List<LngLatAlt>>
 {
+	public static String TYPE_NAME = "MultiLineString";
+	
 	public MultiLineString()
 	{
+		super(TYPE_NAME);
 	}
 
 	@Override public void finishPopulate()
@@ -15,6 +18,7 @@ public class MultiLineString extends Geometry<List<LngLatAlt>>
 
 	public MultiLineString(List<LngLatAlt> line)
 	{
+		super(TYPE_NAME);
 		add(line);
 	}
 }

--- a/library/src/main/java/com/cube/geojson/MultiPoint.java
+++ b/library/src/main/java/com/cube/geojson/MultiPoint.java
@@ -3,8 +3,16 @@ package com.cube.geojson;
 
 public class MultiPoint extends Geometry<LngLatAlt>
 {
+	public static String TYPE_NAME = "MultiPoint";
+
 	public MultiPoint()
 	{
+		super(TYPE_NAME);
+	}
+
+	protected MultiPoint(String type)
+	{
+		super(type);
 	}
 
 	@Override public void finishPopulate()
@@ -14,6 +22,11 @@ public class MultiPoint extends Geometry<LngLatAlt>
 
 	public MultiPoint(LngLatAlt... points)
 	{
-		super(points);
+		super(TYPE_NAME, points);
+	}
+
+	protected MultiPoint(String type, LngLatAlt... points)
+	{
+		super(type, points);
 	}
 }

--- a/library/src/main/java/com/cube/geojson/MultiPolygon.java
+++ b/library/src/main/java/com/cube/geojson/MultiPolygon.java
@@ -4,8 +4,11 @@ import java.util.List;
 
 public class MultiPolygon extends Geometry<List<List<LngLatAlt>>>
 {
+	public static String TYPE_NAME = "MultiPolygon";
+
 	public MultiPolygon()
 	{
+		super(TYPE_NAME);
 	}
 
 	@Override public void finishPopulate()
@@ -49,6 +52,7 @@ public class MultiPolygon extends Geometry<List<List<LngLatAlt>>>
 
 	public MultiPolygon(Polygon polygon)
 	{
+		super(TYPE_NAME);
 		add(polygon);
 	}
 

--- a/library/src/main/java/com/cube/geojson/Point.java
+++ b/library/src/main/java/com/cube/geojson/Point.java
@@ -1,10 +1,12 @@
 package com.cube.geojson;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Point extends GeoJsonObject
 {
 	public static String TYPE_NAME = "Point";
-	
-	protected LngLatAlt coordinates;
+
+	@SerializedName("coordinates") protected LngLatAlt coordinates;
 
 	public Point()
 	{

--- a/library/src/main/java/com/cube/geojson/Point.java
+++ b/library/src/main/java/com/cube/geojson/Point.java
@@ -2,24 +2,53 @@ package com.cube.geojson;
 
 public class Point extends GeoJsonObject
 {
+	public static String TYPE_NAME = "Point";
+	
 	protected LngLatAlt coordinates;
 
 	public Point()
 	{
+		super(TYPE_NAME);
+	}
+
+	protected Point(String type)
+	{
+		super(type);
 	}
 
 	public Point(LngLatAlt coordinates)
 	{
+		super(TYPE_NAME);
+		this.coordinates = coordinates;
+	}
+
+	protected Point(String type, LngLatAlt coordinates)
+	{
+		super(type);
 		this.coordinates = coordinates;
 	}
 
 	public Point(double longitude, double latitude)
 	{
+		super(TYPE_NAME);
+		coordinates = new LngLatAlt(longitude, latitude);
+	}
+
+	protected Point(String type, double longitude, double latitude)
+	{
+		super(type);
 		coordinates = new LngLatAlt(longitude, latitude);
 	}
 
 	public Point(double longitude, double latitude, double altitude)
 	{
+		super(TYPE_NAME);
+		coordinates = new LngLatAlt(longitude, latitude, altitude);
+	}
+
+	protected Point(String type, double longitude, double latitude, double altitude)
+	{
+		super(type);
 		coordinates = new LngLatAlt(longitude, latitude, altitude);
 	}
 

--- a/library/src/main/java/com/cube/geojson/Polygon.java
+++ b/library/src/main/java/com/cube/geojson/Polygon.java
@@ -5,8 +5,11 @@ import java.util.List;
 
 public class Polygon extends Geometry<List<LngLatAlt>>
 {
+	public static String TYPE_NAME = "Polygon";
+
 	public Polygon()
 	{
+		super(TYPE_NAME);
 	}
 
 	@Override public void finishPopulate()
@@ -16,11 +19,13 @@ public class Polygon extends Geometry<List<LngLatAlt>>
 
 	public Polygon(List<LngLatAlt> polygon)
 	{
+		super(TYPE_NAME);
 		add(polygon);
 	}
 
 	public Polygon(LngLatAlt... polygon)
 	{
+		super(TYPE_NAME);
 		add(Arrays.asList(polygon));
 	}
 

--- a/library/src/main/java/com/cube/geojson/gson/GeoJsonObjectAdapter.java
+++ b/library/src/main/java/com/cube/geojson/gson/GeoJsonObjectAdapter.java
@@ -25,28 +25,38 @@ import com.google.gson.JsonSyntaxException;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Adapter for GeoJson objects
  */
 public class GeoJsonObjectAdapter implements JsonSerializer<GeoJsonObject>, JsonDeserializer<GeoJsonObject>
 {
-	private static HashMap<String, String> lowerCaseMap;
+	private static final HashMap<String, Class<?>> classMap;
+	private static final HashMap<String, Class<?>> lowercaseClassMap;
+
+	private static void registerType(String type, Class<?> clazz)
+	{
+		classMap.put(type, clazz);
+		lowercaseClassMap.put(type.toLowerCase(Locale.ENGLISH), clazz);
+	}
 
 	static
 	{
-		lowerCaseMap = new HashMap<String, String>();
-		lowerCaseMap.put(Crs.class.getSimpleName().toLowerCase(), Crs.class.getSimpleName());
-		lowerCaseMap.put(Feature.class.getSimpleName().toLowerCase(), Feature.class.getSimpleName());
-		lowerCaseMap.put(FeatureCollection.class.getSimpleName().toLowerCase(), FeatureCollection.class.getSimpleName());
-		lowerCaseMap.put(GeometryCollection.class.getSimpleName().toLowerCase(), GeometryCollection.class.getSimpleName());
-		lowerCaseMap.put(LineString.class.getSimpleName().toLowerCase(), LineString.class.getSimpleName());
-		lowerCaseMap.put(MultiLineString.class.getSimpleName().toLowerCase(), MultiLineString.class.getSimpleName());
-		lowerCaseMap.put(MultiPoint.class.getSimpleName().toLowerCase(), MultiPoint.class.getSimpleName());
-		lowerCaseMap.put(MultiPolygon.class.getSimpleName().toLowerCase(), MultiPolygon.class.getSimpleName());
-		lowerCaseMap.put(Point.class.getSimpleName().toLowerCase(), Point.class.getSimpleName());
-		lowerCaseMap.put(Polygon.class.getSimpleName().toLowerCase(), Polygon.class.getSimpleName());
-		lowerCaseMap.put(Circle.class.getSimpleName().toLowerCase(), Circle.class.getSimpleName());
+		classMap = new HashMap<>();
+		lowercaseClassMap = new HashMap<>();
+		registerType("Crs", Crs.class);
+		registerType(Feature.TYPE_NAME, Feature.class);
+		registerType(FeatureCollection.TYPE_NAME, FeatureCollection.class);
+		registerType(GeometryCollection.TYPE_NAME, GeometryCollection.class);
+		registerType(LineString.TYPE_NAME, LineString.class);
+		registerType(MultiLineString.TYPE_NAME, MultiLineString.class);
+		registerType(MultiPoint.TYPE_NAME, MultiPoint.class);
+		registerType(MultiPolygon.TYPE_NAME, MultiPolygon.class);
+		registerType(Point.TYPE_NAME, Point.class);
+		registerType(Polygon.TYPE_NAME, Polygon.class);
+		registerType(Circle.TYPE_NAME, Circle.class);
 	}
 
 	@Override
@@ -77,17 +87,18 @@ public class GeoJsonObjectAdapter implements JsonSerializer<GeoJsonObject>, Json
 		JsonObject jsonObject = json.getAsJsonObject();
 		String type = jsonObject.get("type").getAsString();
 
-		if (GeoJson.isUsingLowerCaseTypes && lowerCaseMap.containsKey(type))
+		Map<String, Class<?>> map = classMap;
+		if (GeoJson.isUsingLowerCaseTypes)
 		{
-			type = lowerCaseMap.get(type);
+			map = lowercaseClassMap;
 		}
 
 		Class<GeoJsonObject> cls;
 		try
 		{
-			cls = (Class<GeoJsonObject>)Class.forName(GeoJson.class.getPackage().getName().concat(".").concat(type));
+			cls = (Class<GeoJsonObject>) map.get(type);
 		}
-		catch (ClassNotFoundException e)
+		catch (ClassCastException e)
 		{
 			e.printStackTrace();
 			throw new JsonParseException(e.getMessage());

--- a/library/src/test/java/com/cube/geojson/test/GeoJsonObjectTest.java
+++ b/library/src/test/java/com/cube/geojson/test/GeoJsonObjectTest.java
@@ -13,6 +13,11 @@ public class GeoJsonObjectTest
 
 	private class TestGeoJsonObject extends GeoJsonObject
 	{
+		public TestGeoJsonObject()
+		{
+			super("TestGeoJsonObject");
+		}
+
 		@Override public void finishPopulate()
 		{
 		}


### PR DESCRIPTION
## What?

Chores:
 - Bumps version to `1.8.0-rc1` 

Fixes:
 - Upgrades gradle wrapper to `9.0` milestone 1 and updates the gradle configuration so that the project is able to sync 
 - Upgrades the java source compatibility to Java 17 
 - Bumps AGP version up to `8.13.0` 
 - Fixes `artifactory.gradle` publishing issues 

Features:
 - Updates all `GeoJson` objects to use statically declared type names so that proguard / r8 obfuscation doesn't cause the classes to not be found when serialising/deserialising
 - Updates all `GeoJson` objects to use the `SerializedName` annotation on all of their fields so that proguard / r8 obfuscation doesn't cause the fields to not be found when serialising/deserialising 

## Why?

If an Android application that uses this dependency turns on Proguard / minification with R8, then the names of the classes and fields may change.

This would cause Gson to fail to serialise and deserialise the data correctly, as `GeoJsonObjectAdapter` uses class names to resolve the type to deserialise as, and Gson (by default) uses the java class field names to determine what fields should be present in the JSON.

This PR resolves this by:
- Updating `GeoJsonObjectAdapter` to remove uses of `getSimpleName()` and `Class.getName()`
- Annotating all relevant fields with `SerializedName`