### PR TITLE
:NORMAL: Feature/add serial version ids [Small PR]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.8.0-rc2
+VERSION_NAME=1.8.0-rc3
 GROUP=com.3sidedcube.util
 
 POM_NAME=GeoGson

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.8.0-rc3
+VERSION_NAME=1.8.0-rc4
 GROUP=com.3sidedcube.util
 
 POM_NAME=GeoGson

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.8.0-rc1
+VERSION_NAME=1.8.0-rc2
 GROUP=com.3sidedcube.util
 
 POM_NAME=GeoGson

--- a/library/src/main/java/com/cube/geojson/Circle.java
+++ b/library/src/main/java/com/cube/geojson/Circle.java
@@ -2,8 +2,13 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
+
 public class Circle extends Point
 {
+	@Serial
+	private static final long serialVersionUID = -8355841497926170670L;
+
 	public static String TYPE_NAME = "Circle";
 	@SerializedName("radius") private double radius;
 

--- a/library/src/main/java/com/cube/geojson/Feature.java
+++ b/library/src/main/java/com/cube/geojson/Feature.java
@@ -2,8 +2,13 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
+
 public class Feature extends GeoJsonObject
 {
+	@Serial
+	private static final long serialVersionUID = 5351451912626812523L;
+
 	public static String TYPE_NAME = "Feature";
 	@SerializedName("geometry") private GeoJsonObject geometry;
 	@SerializedName("id") private String id;

--- a/library/src/main/java/com/cube/geojson/FeatureCollection.java
+++ b/library/src/main/java/com/cube/geojson/FeatureCollection.java
@@ -2,6 +2,7 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -9,6 +10,9 @@ import java.util.List;
 
 public class FeatureCollection extends GeoJsonObject implements Iterable<Feature>
 {
+	@Serial
+	private static final long serialVersionUID = -9218604739570504767L;
+
 	public static String TYPE_NAME = "FeatureCollection";
 
 	public FeatureCollection()

--- a/library/src/main/java/com/cube/geojson/GeoJsonObject.java
+++ b/library/src/main/java/com/cube/geojson/GeoJsonObject.java
@@ -2,12 +2,16 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class GeoJsonObject implements Serializable
 {
+	@Serial
+	private static final long serialVersionUID = 8674973001553464365L;
+
 	@SerializedName("type") protected String type;
 	@SerializedName("crs") private Crs crs;
 	@SerializedName("bbox") private double[] bbox;

--- a/library/src/main/java/com/cube/geojson/Geometry.java
+++ b/library/src/main/java/com/cube/geojson/Geometry.java
@@ -2,11 +2,15 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class Geometry<T> extends GeoJsonObject
 {
+	@Serial
+	private static final long serialVersionUID = -6481665000987288570L;
+
 	@SerializedName("coordinates") protected List<T> coordinates = new ArrayList<>();
 
 	protected Geometry(String type)

--- a/library/src/main/java/com/cube/geojson/GeometryCollection.java
+++ b/library/src/main/java/com/cube/geojson/GeometryCollection.java
@@ -2,12 +2,16 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJsonObject>
 {
+	@Serial
+	private static final long serialVersionUID = -3111720313954782292L;
+
 	public static String TYPE_NAME = "GeometryCollection";
 
 	public GeometryCollection()

--- a/library/src/main/java/com/cube/geojson/LngLatAlt.java
+++ b/library/src/main/java/com/cube/geojson/LngLatAlt.java
@@ -2,10 +2,14 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class LngLatAlt implements Serializable
 {
+	@Serial
+	private static final long serialVersionUID = 5661286917817657765L;
+
 	@SerializedName("longitude") private double longitude;
 	@SerializedName("latitude") private double latitude;
 	@SerializedName("altitude") private double altitude = Double.NaN;

--- a/library/src/main/java/com/cube/geojson/MultiLineString.java
+++ b/library/src/main/java/com/cube/geojson/MultiLineString.java
@@ -1,9 +1,13 @@
 package com.cube.geojson;
 
+import java.io.Serial;
 import java.util.List;
 
 public class MultiLineString extends Geometry<List<LngLatAlt>>
 {
+	@Serial
+	private static final long serialVersionUID = 5954111454087547522L;
+
 	public static String TYPE_NAME = "MultiLineString";
 	
 	public MultiLineString()

--- a/library/src/main/java/com/cube/geojson/MultiPoint.java
+++ b/library/src/main/java/com/cube/geojson/MultiPoint.java
@@ -1,8 +1,13 @@
 package com.cube.geojson;
 
 
+import java.io.Serial;
+
 public class MultiPoint extends Geometry<LngLatAlt>
 {
+	@Serial
+	private static final long serialVersionUID = -4722499037817102713L;
+
 	public static String TYPE_NAME = "MultiPoint";
 
 	public MultiPoint()

--- a/library/src/main/java/com/cube/geojson/MultiPolygon.java
+++ b/library/src/main/java/com/cube/geojson/MultiPolygon.java
@@ -1,9 +1,13 @@
 package com.cube.geojson;
 
+import java.io.Serial;
 import java.util.List;
 
 public class MultiPolygon extends Geometry<List<List<LngLatAlt>>>
 {
+	@Serial
+	private static final long serialVersionUID = -191681831119666019L;
+
 	public static String TYPE_NAME = "MultiPolygon";
 
 	public MultiPolygon()

--- a/library/src/main/java/com/cube/geojson/Point.java
+++ b/library/src/main/java/com/cube/geojson/Point.java
@@ -2,8 +2,13 @@ package com.cube.geojson;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serial;
+
 public class Point extends GeoJsonObject
 {
+	@Serial
+	private static final long serialVersionUID = -4043883441163707153L;
+
 	public static String TYPE_NAME = "Point";
 
 	@SerializedName("coordinates") protected LngLatAlt coordinates;

--- a/library/src/main/java/com/cube/geojson/Polygon.java
+++ b/library/src/main/java/com/cube/geojson/Polygon.java
@@ -1,10 +1,14 @@
 package com.cube.geojson;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.List;
 
 public class Polygon extends Geometry<List<LngLatAlt>>
 {
+	@Serial
+	private static final long serialVersionUID = 3863207152526191906L;
+
 	public static String TYPE_NAME = "Polygon";
 
 	public Polygon()


### PR DESCRIPTION
## What?

- Adds explicit `serialVersionUID` fields to all `Serializable` classes
- Bumps version code to release candidate 4

## Why?

Having explicit `serialVersionUID`s ensures that serialised data maintains compatibility even if obfuscation is enabled.

See #4 for more context on this.