### PR TITLE
:HIGH: Fix/obfuscated serialisation [Small PR]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.8.0-rc4
+VERSION_NAME=1.8.0-rc5
 GROUP=com.3sidedcube.util
 
 POM_NAME=GeoGson

--- a/library/src/main/java/com/cube/geojson/gson/GeoJsonObjectAdapter.java
+++ b/library/src/main/java/com/cube/geojson/gson/GeoJsonObjectAdapter.java
@@ -63,12 +63,18 @@ public class GeoJsonObjectAdapter implements JsonSerializer<GeoJsonObject>, Json
 	@SuppressWarnings("unchecked")
 	public JsonElement serialize(GeoJsonObject src, Type typeOfSrc, JsonSerializationContext context)
 	{
+		Map<String, Class<?>> map = classMap;
+		if (GeoJson.isUsingLowerCaseTypes)
+		{
+			map = lowercaseClassMap;
+		}
+
 		Class<GeoJsonObject> cls;
 		try
 		{
-			cls = (Class<GeoJsonObject>)Class.forName(GeoJson.class.getPackage().getName().concat(".").concat(src.getType()));
+			cls = (Class<GeoJsonObject>) map.get(src.getType());
 		}
-		catch (ClassNotFoundException e)
+		catch (ClassCastException e)
 		{
 			e.printStackTrace();
 			throw new JsonSyntaxException(e.getMessage());


### PR DESCRIPTION
## What?

Chores:
 - Bumps version to `1.8.0-rc5` 

Fixes:
 - Fixes `GeoJsonObjectAdapter.serialize` so that proguard / r8 obfuscation doesn't cause the class to not be found when serialising 

## Why?

If an Android application that uses this dependency turns on Proguard / minification with R8, then the names of the classes and fields may change.

This use of `Class.forName` in `GeoJsonObjectAdapter.serialize` therefore would fail with obfuscation turned on.

This PR fixes this.